### PR TITLE
Mensajería: añadir papelera, restaurar y eliminación definitiva; normalizar roles

### DIFF
--- a/app/Http/Controllers/EmailController.php
+++ b/app/Http/Controllers/EmailController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\Emails;
 use App\Models\EmailsAttachments;
 use App\Models\EmailsRecipient;
-use App\Models\Messages;
 use App\Models\User;
 use App\Notifications\AnnouncementNotification;
 use Illuminate\Http\Request;
@@ -117,17 +116,20 @@ class EmailController extends Controller
 
     private function getRecipients($to)
     {
+        $query = User::query()
+            ->where('id', '!=', Auth::id())
+            ->where('school_id', Auth::user()->school->id);
+
         if (Str::startsWith($to, 'role:')) {
-            $role = Str::after($to, 'role:');
-            return User::whereHas('roles', fn($q) => $q->where('name', $role))->get();
+            $role = $this->normalizeRole(Str::after($to, 'role:'));
+            return $query->whereHas('roles', fn($q) => $q->where('name', $role))->get();
         }
 
         if ($to == '0') {
-            return User::where('id', '!=', Auth::id())->get();
+            return $query->get();
         }
 
-
-        return User::where('id', $to)->get();
+        return $query->where('id', $to)->get();
     }
 
     private function saveSenderEmailData(Request $request)
@@ -162,6 +164,7 @@ class EmailController extends Controller
         $data_message = EmailsRecipient::with('email.sender', 'email.attachments')
             ->where('recipient_id', Auth::id())
             ->where('email_id', $message_id)
+            ->whereNull('deleted_at')
             ->firstOrFail();
 
         // actualizar data para marcar como leído
@@ -251,7 +254,6 @@ class EmailController extends Controller
                     $q->where('subject', 'like', "%$search%");
                 });
             })
-            ->where('id', '!=', 24)
             ->orderByDesc('created_at')
             ->paginate(10);
 
@@ -261,4 +263,87 @@ class EmailController extends Controller
 
         return view('messages.sent', compact('messages', 'count_no_read'));
     }
+    public function trash(Request $request)
+    {
+        $user = Auth::user();
+        $search = $request->get('q');
+
+        $messages = EmailsRecipient::with('email.sender', 'email.attachments')
+            ->where('recipient_id', $user->id)
+            ->whereNotNull('deleted_at')
+            ->when($search, function ($query, $search) {
+                $query->where(function ($q) use ($search) {
+                    $q->whereHas('email', function ($q2) use ($search) {
+                        $q2->where('subject', 'like', "%$search%");
+                    })->orWhereHas('email.sender', function ($q2) use ($search) {
+                        $q2->where('name', 'like', "%$search%");
+                    });
+                });
+            })
+            ->orderByDesc('updated_at')
+            ->paginate(10);
+
+        $count_no_read = EmailsRecipient::where('is_read', false)
+            ->where('recipient_id', $user->id)
+            ->whereNull('deleted_at')
+            ->count();
+
+        return view('messages.trash', compact('messages', 'count_no_read'));
+    }
+
+    public function destroy(int $message_id)
+    {
+        $messageRecipient = EmailsRecipient::where('recipient_id', Auth::id())
+            ->where('email_id', $message_id)
+            ->whereNull('deleted_at')
+            ->firstOrFail();
+
+        $messageRecipient->update(['deleted_at' => now()]);
+
+        return response()->json(['success' => true]);
+    }
+
+    public function restore(int $message_id)
+    {
+        $messageRecipient = EmailsRecipient::where('recipient_id', Auth::id())
+            ->where('email_id', $message_id)
+            ->whereNotNull('deleted_at')
+            ->firstOrFail();
+
+        $messageRecipient->update(['deleted_at' => null]);
+
+        return response()->json(['success' => true]);
+    }
+
+    public function forceDelete(int $message_id)
+    {
+        $messageRecipient = EmailsRecipient::where('recipient_id', Auth::id())
+            ->where('email_id', $message_id)
+            ->whereNotNull('deleted_at')
+            ->firstOrFail();
+
+        $messageRecipient->delete();
+
+        return response()->json(['success' => true]);
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        $normalized = Str::lower(trim($role));
+
+        $map = [
+            'profesor' => 'Docente',
+            'profesores' => 'Docente',
+            'docente' => 'Docente',
+            'docentes' => 'Docente',
+            'alumno' => 'Alumno',
+            'alumnos' => 'Alumno',
+            'padre' => 'Padre',
+            'padres' => 'Padre',
+            'colegio' => 'Colegio',
+        ];
+
+        return $map[$normalized] ?? ucfirst($normalized);
+    }
+
 }

--- a/resources/views/messages/create.blade.php
+++ b/resources/views/messages/create.blade.php
@@ -29,7 +29,7 @@
                                                     <option value="0">Todos los usuarios</option>
                                                     <option value="role:Padre">Todos los padres</option>
                                                     <option value="role:Alumno">Todos los alumnos</option>
-                                                    <option value="role:Profesor">Todos los profesores</option>
+                                                    <option value="role:Docente">Todos los profesores</option>
                                                 @endif
 
                                                 @if (Auth::user()->hasRole('Docente'))
@@ -37,7 +37,7 @@
                                                 @endif
 
                                                 @if (Auth::user()->hasRole('Alumno'))
-                                                    <option value="role:Profesor">Todos los profesores</option>
+                                                    <option value="role:Docente">Todos los profesores</option>
                                                 @endif
 
                                                 @php $currentRole = null; @endphp

--- a/resources/views/messages/options.blade.php
+++ b/resources/views/messages/options.blade.php
@@ -25,6 +25,12 @@
                 </a>
             </li>
 
+            <li class="{{ request()->routeIs('mensajes.trash') ? 'active' : '' }}">
+                <a href="{{ route('mensajes.trash') }}">
+                    <i class="fas fa-trash mr-1"></i> Papelera
+                </a>
+            </li>
+
             <li class="{{ request()->routeIs('mensajes.create') ? 'active' : '' }}">
                 <a href="{{ route('mensajes.create') }}">
                     <i class="fas fa-envelope mr-1"></i> Enviar mensaje

--- a/resources/views/messages/trash.blade.php
+++ b/resources/views/messages/trash.blade.php
@@ -9,9 +9,9 @@
                     <div class="page-content mail-content">
                         <div class="inbox-head d-lg-flex d-block">
                             <h3>Papelera</h3>
-                            <form action="#" class="ml-auto">
+                            <form action="{{ route('mensajes.trash') }}" method="GET" class="ml-auto">
                                 <div class="input-group">
-                                    <input type="text" placeholder="Buscar mensaje" class="form-control">
+                                    <input type="text" name="q" value="{{ request('q') }}" placeholder="Buscar mensaje" class="form-control">
                                     <div class="input-group-append">
                                         <span class="input-group-text">
                                             <i class="fa fa-search search-icon"></i>
@@ -21,9 +21,7 @@
                             </form>
                         </div>
                         <div class="inbox-body">
-                            @include('messages.list_options_filters')
-
-                            @forelse ($messages as $item)
+                                                        @forelse ($messages as $item)
                                 <div class="email-list">
                                     <div class="email-list-item {{ $item->is_read ? '' : 'unread' }}">
                                         <div class="email-list-actions">
@@ -33,8 +31,8 @@
                                                     <span class="custom-control-label"></span>
                                                 </label>
                                                 <span class="rating rating-sm mr-3">
-                                                    <input type="checkbox" id="star{{ $item->id }}" value="1">
-                                                    <label for="star{{ $item->id }}">
+                                                    <input type="checkbox" id="star{{ $item->email_id }}" value="1">
+                                                    <label for="star{{ $item->email_id }}">
                                                         <span class="fa fa-star"></span>
                                                     </label>
                                                 </span>
@@ -42,21 +40,21 @@
                                         </div>
                                         <div class="email-list-detail">
                                             <span class="date float-right">
-                                                @if ($item->files->count() > 0)
+                                                @if ($item->email->attachments->count() > 0)
                                                     <i class="fa fa-paperclip paperclip"></i>
                                                 @endif
                                                 {{ $item->created_at->format('d M') }}
                                             </span>
-                                            <span class="from">{{ $item->sender->name }}</span>
-                                            <p class="msg">{{ $item->subject }}</p>
+                                            <span class="from">{{ $item->email->sender->name }}</span>
+                                            <p class="msg">{{ $item->email->subject }}</p>
 
                                             <div class="actions mt-2">
                                                 <button class="btn btn-success btn-sm restore-message"
-                                                    data-id="{{ $item->id }}">
+                                                    data-id="{{ $item->email_id }}">
                                                     <i class="fa fa-undo"></i> Restaurar
                                                 </button>
                                                 <button class="btn btn-danger btn-sm delete-message"
-                                                    data-id="{{ $item->id }}">
+                                                    data-id="{{ $item->email_id }}">
                                                     <i class="fa fa-trash"></i> Eliminar definitivamente
                                                 </button>
                                             </div>
@@ -68,6 +66,9 @@
                                     <p class="msg text-center">No tienes mensajes en la papelera.</p>
                                 </div>
                             @endforelse
+                        </div>
+                        <div class="mt-4 d-flex justify-content-center">
+                            {{ $messages->links() }}
                         </div>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,9 +37,12 @@ Route::middleware(['auth'])->group(function () {
         Route::get('crear', [EmailController::class, 'create'])->name('create'); // Crear mensaje
         Route::post('enviar', [EmailController::class, 'send'])->name('send'); // Enviar mensaje
         Route::get('enviados', [EmailController::class, 'sent'])->name('enviados'); // 🔄 Mover aquí
+        Route::get('papelera', [EmailController::class, 'trash'])->name('trash');
         Route::post('{id}/reply', [EmailController::class, 'reply'])->name('reply');
-        Route::get('{id_mensaje}', [EmailController::class, 'show'])->name('show'); // Ver mensaje
         Route::get('enviados/{id_mensaje}', [EmailController::class, 'show_sent'])->name('show_sent'); // Ver mensaje
+        Route::patch('{id_mensaje}/restore', [EmailController::class, 'restore'])->name('restore');
+        Route::delete('{id_mensaje}/force-delete', [EmailController::class, 'forceDelete'])->name('force_delete');
+        Route::get('{id_mensaje}', [EmailController::class, 'show'])->name('show'); // Ver mensaje
 
         Route::delete('{id_mensaje}', [EmailController::class, 'destroy'])->name('destroy'); // Eliminar mensaje
     });


### PR DESCRIPTION
### Motivation
- Añadir soporte de flujo completo de mensajería para el destinatario: ver papelera, mover a papelera (soft-delete por destinatario), restaurar y eliminar definitivamente el vínculo del mensaje.
- Evitar inconsistencias al seleccionar destinatarios por rol y restringir envíos al mismo colegio.

### Description
- Agregadas rutas nuevas en `routes/web.php` para `mensajes.papelera` (`GET /mensajes/papelera`), restaurar (`PATCH /mensajes/{id}/restore`) y eliminación definitiva (`DELETE /mensajes/{id}/force-delete`).
- Implementados en `EmailController` los métodos `trash()`, `destroy()` (mover a papelera por `emails_recipients`), `restore()` y `forceDelete()` y se ajustó `show()` para ignorar mensajes borrados por el destinatario.
- Mejorada la selección de destinatarios con `getRecipients()` para limitar al `school_id` del usuario y añadida `normalizeRole()` para mapear variantes (e.g. `Profesor` → `Docente`) antes de filtrar por roles.
- Actualizadas vistas: añadido enlace a Papelera en `resources/views/messages/options.blade.php`, corregida la vista de creación `resources/views/messages/create.blade.php` para usar `role:Docente`, y adaptada `resources/views/messages/trash.blade.php` para consumir `emails_recipients` con relaciones `email->sender`/`email->attachments` y paginación.

### Testing
- Ejecutado `php -l app/Http/Controllers/EmailController.php` y `php -l routes/web.php`, ambos devolveron sin errores de sintaxis (éxito).
- Intentado `php artisan route:list --name=mensajes` pero no pudo ejecutarse en este entorno por falta de dependencias (`vendor/autoload.php`), por lo que la verificación dinámica de rutas no se realizó (fallido por entorno, no por código).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f64d98a4832ab1e86a6c1bc61283)