### PR TITLE
Agregar módulo de foros por materia con publicaciones, adjuntos, comentarios y notificaciones

### DIFF
--- a/app/Http/Controllers/ForumController.php
+++ b/app/Http/Controllers/ForumController.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Forum;
+use App\Models\ForumComment;
+use App\Models\ForumMessage;
+use App\Models\ForumMessageAttachment;
+use App\Models\Materias;
+use App\Models\User;
+use App\Notifications\ForumMessageNotification;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+
+class ForumController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        $subjectIds = $this->getUserSubjectIds($user);
+
+        $materias = Materias::query()
+            ->where('school_id', $user->school_id)
+            ->whereIn('id', $subjectIds)
+            ->with(['cursos', 'forums' => function ($query) {
+                $query->withCount('messages')->orderByDesc('updated_at');
+            }])
+            ->orderBy('nombre')
+            ->get();
+
+        return view('forums.index', compact('materias'));
+    }
+
+    public function create()
+    {
+        $this->authorizeManagement();
+
+        $materias = Materias::query()
+            ->where('school_id', Auth::user()->school_id)
+            ->orderBy('nombre')
+            ->get();
+
+        return view('forums.form', [
+            'forum' => new Forum(),
+            'materias' => $materias,
+            'isEdit' => false,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $this->authorizeManagement();
+
+        $validated = $request->validate([
+            'materia_id' => 'required|exists:materias,id',
+            'title' => 'required|string|max:150',
+            'description' => 'nullable|string|max:2000',
+        ]);
+
+        Forum::create([
+            'school_id' => Auth::user()->school_id,
+            'materia_id' => $validated['materia_id'],
+            'title' => $validated['title'],
+            'description' => $validated['description'] ?? null,
+            'created_by' => Auth::id(),
+            'updated_by' => Auth::id(),
+            'is_active' => true,
+        ]);
+
+        return redirect()->route('forums.index')->with('success', 'Foro creado correctamente.');
+    }
+
+    public function show($id)
+    {
+        $forum = Forum::with(['materia.cursos', 'messages.user', 'messages.attachments', 'messages.comments.user'])
+            ->findOrFail($id);
+
+        $this->authorizeForumAccess($forum);
+
+        return view('forums.show', compact('forum'));
+    }
+
+    public function edit($id)
+    {
+        $this->authorizeManagement();
+        $forum = Forum::findOrFail($id);
+
+        $materias = Materias::query()
+            ->where('school_id', Auth::user()->school_id)
+            ->orderBy('nombre')
+            ->get();
+
+        return view('forums.form', [
+            'forum' => $forum,
+            'materias' => $materias,
+            'isEdit' => true,
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $this->authorizeManagement();
+        $forum = Forum::findOrFail($id);
+
+        $validated = $request->validate([
+            'materia_id' => 'required|exists:materias,id',
+            'title' => 'required|string|max:150',
+            'description' => 'nullable|string|max:2000',
+        ]);
+
+        $forum->update([
+            'materia_id' => $validated['materia_id'],
+            'title' => $validated['title'],
+            'description' => $validated['description'] ?? null,
+            'updated_by' => Auth::id(),
+        ]);
+
+        return redirect()->route('forums.show', $forum->id)->with('success', 'Foro actualizado correctamente.');
+    }
+
+    public function toggleStatus($id)
+    {
+        $this->authorizeManagement();
+        $forum = Forum::findOrFail($id);
+
+        $forum->is_active = !$forum->is_active;
+        $forum->disabled_at = $forum->is_active ? null : now();
+        $forum->updated_by = Auth::id();
+        $forum->save();
+
+        return redirect()->route('forums.show', $forum->id)->with('success', 'Estado del foro actualizado.');
+    }
+
+    public function storeMessage(Request $request, $forumId)
+    {
+        $forum = Forum::findOrFail($forumId);
+        $this->authorizeForumAccess($forum);
+
+        if (!$forum->is_active) {
+            return back()->with('error', 'No se pueden publicar mensajes en foros inactivos.');
+        }
+
+        $validated = $request->validate([
+            'body' => 'required|string|max:5000',
+            'attachments.*' => 'file|max:5120|mimes:jpg,jpeg,png,pdf,doc,docx,xls,xlsx,zip',
+        ]);
+
+        DB::transaction(function () use ($validated, $request, $forum) {
+            $message = ForumMessage::create([
+                'forum_id' => $forum->id,
+                'user_id' => Auth::id(),
+                'body' => $validated['body'],
+            ]);
+
+            if ($request->hasFile('attachments')) {
+                foreach ($request->file('attachments') as $file) {
+                    $path = $file->store('forum_attachments', 'public');
+                    ForumMessageAttachment::create([
+                        'forum_message_id' => $message->id,
+                        'file_path' => $path,
+                        'file_name' => $file->getClientOriginalName(),
+                        'mime_type' => $file->getClientMimeType(),
+                        'file_size' => $file->getSize(),
+                    ]);
+                }
+            }
+
+            $recipients = $this->getForumUsers($forum)->where('id', '!=', Auth::id());
+            if ($recipients->isNotEmpty()) {
+                Notification::send($recipients, new ForumMessageNotification($forum, $message));
+            }
+        });
+
+        return redirect()->route('forums.show', $forum->id)->with('success', 'Mensaje publicado correctamente.');
+    }
+
+    public function storeComment(Request $request, $forumId, $messageId)
+    {
+        $forum = Forum::findOrFail($forumId);
+        $this->authorizeForumAccess($forum);
+
+        if (!$forum->is_active) {
+            return back()->with('error', 'No se pueden comentar foros inactivos.');
+        }
+
+        $request->validate([
+            'body' => 'required|string|max:1500',
+        ]);
+
+        $message = ForumMessage::where('forum_id', $forum->id)->findOrFail($messageId);
+
+        ForumComment::create([
+            'forum_message_id' => $message->id,
+            'user_id' => Auth::id(),
+            'body' => $request->input('body'),
+        ]);
+
+        return redirect()->route('forums.show', $forum->id)->with('success', 'Comentario agregado correctamente.');
+    }
+
+    private function authorizeManagement()
+    {
+        if (!Auth::user()->hasAnyRole(['Colegio', 'Docente'])) {
+            abort(403);
+        }
+    }
+
+    private function authorizeForumAccess(Forum $forum)
+    {
+        $user = Auth::user();
+        if ((int) $forum->school_id !== (int) $user->school_id) {
+            abort(403);
+        }
+
+        $subjectIds = $this->getUserSubjectIds($user);
+        if (!$subjectIds->contains((int) $forum->materia_id)) {
+            abort(403);
+        }
+    }
+
+    private function getUserSubjectIds(User $user)
+    {
+        if ($user->hasRole('Colegio')) {
+            return Materias::where('school_id', $user->school_id)->pluck('id');
+        }
+
+        if ($user->hasRole('Docente')) {
+            return DB::table('subject_teacher as st')
+                ->join('profesors as p', 'p.id', '=', 'st.teacher_id')
+                ->where('p.user_id', $user->id)
+                ->pluck('st.subject_courses_id')
+                ->unique()
+                ->values();
+        }
+
+        if ($user->hasAnyRole(['Alumno', 'Estudiante'])) {
+            return DB::table('students')
+                ->join('materias', 'materias.curso_id', '=', 'students.curso_id')
+                ->where('students.user_id', $user->id)
+                ->pluck('materias.id')
+                ->unique()
+                ->values();
+        }
+
+        return collect();
+    }
+
+    private function getForumUsers(Forum $forum)
+    {
+        $teacherUserIds = DB::table('subject_teacher as st')
+            ->join('profesors as p', 'p.id', '=', 'st.teacher_id')
+            ->where('st.subject_courses_id', $forum->materia_id)
+            ->pluck('p.user_id');
+
+        $studentUserIds = DB::table('materias')
+            ->join('students', 'students.curso_id', '=', 'materias.curso_id')
+            ->where('materias.id', $forum->materia_id)
+            ->pluck('students.user_id');
+
+        $schoolUsers = User::role('Colegio')
+            ->where('school_id', $forum->school_id)
+            ->pluck('id');
+
+        $userIds = $teacherUserIds
+            ->merge($studentUserIds)
+            ->merge($schoolUsers)
+            ->unique()
+            ->values();
+
+        return User::whereIn('id', $userIds)->get();
+    }
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -2,14 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-
 class NotificationController extends Controller
 {
     public function index()
     {
-        // Obtener las notificaciones del usuario autenticado
-        $notifications = auth()->user()->unreadNotifications;
+        $notifications = auth()->user()->notifications()->latest()->paginate(20);
 
         return view('notifications.index', compact('notifications'));
     }

--- a/app/Models/Forum.php
+++ b/app/Models/Forum.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Forum extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'school_id',
+        'materia_id',
+        'title',
+        'description',
+        'is_active',
+        'created_by',
+        'updated_by',
+        'disabled_at',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'disabled_at' => 'datetime',
+    ];
+
+    public function materia()
+    {
+        return $this->belongsTo(Materias::class, 'materia_id');
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(ForumMessage::class);
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/ForumComment.php
+++ b/app/Models/ForumComment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ForumComment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'forum_message_id',
+        'user_id',
+        'body',
+    ];
+
+    public function message()
+    {
+        return $this->belongsTo(ForumMessage::class, 'forum_message_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ForumMessage.php
+++ b/app/Models/ForumMessage.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ForumMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'forum_id',
+        'user_id',
+        'body',
+    ];
+
+    public function forum()
+    {
+        return $this->belongsTo(Forum::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function attachments()
+    {
+        return $this->hasMany(ForumMessageAttachment::class);
+    }
+
+    public function comments()
+    {
+        return $this->hasMany(ForumComment::class)->latest();
+    }
+}

--- a/app/Models/ForumMessageAttachment.php
+++ b/app/Models/ForumMessageAttachment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ForumMessageAttachment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'forum_message_id',
+        'file_path',
+        'file_name',
+        'mime_type',
+        'file_size',
+    ];
+
+    public function message()
+    {
+        return $this->belongsTo(ForumMessage::class, 'forum_message_id');
+    }
+}

--- a/app/Models/Materias.php
+++ b/app/Models/Materias.php
@@ -41,6 +41,11 @@ class Materias extends Model
         return $this->hasMany(MateriasHorarios::class, 'subject_course_id', 'id');
     }
 
+    public function forums()
+    {
+        return $this->hasMany(Forum::class, 'materia_id')->orderByDesc('updated_at');
+    }
+
     public static function calculateHours($start_time, $end_time)
     {
         $start = Carbon::parse($start_time);

--- a/app/Notifications/ForumMessageNotification.php
+++ b/app/Notifications/ForumMessageNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Forum;
+use App\Models\ForumMessage;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class ForumMessageNotification extends Notification
+{
+    use Queueable;
+
+    protected $forum;
+    protected $message;
+
+    public function __construct(Forum $forum, ForumMessage $message)
+    {
+        $this->forum = $forum;
+        $this->message = $message;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'title' => 'Nuevo mensaje en foro',
+            'subject' => $this->forum->title,
+            'message' => mb_strimwidth(strip_tags($this->message->body), 0, 120, '...'),
+            'forum_id' => $this->forum->id,
+            'url' => route('forums.show', $this->forum->id),
+            'icon' => 'fa-comments',
+        ];
+    }
+}

--- a/database/migrations/2026_02_27_000001_create_forums_table.php
+++ b/database/migrations/2026_02_27_000001_create_forums_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateForumsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('forums', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('school_id');
+            $table->unsignedBigInteger('materia_id');
+            $table->string('title', 150);
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamp('disabled_at')->nullable();
+            $table->unsignedBigInteger('created_by');
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+
+            $table->foreign('school_id')->references('id')->on('schools')->onDelete('cascade');
+            $table->foreign('materia_id')->references('id')->on('materias')->onDelete('cascade');
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('updated_by')->references('id')->on('users')->nullOnDelete();
+
+            $table->index(['school_id', 'materia_id', 'is_active']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('forums');
+    }
+}

--- a/database/migrations/2026_02_27_000002_create_forum_messages_table.php
+++ b/database/migrations/2026_02_27_000002_create_forum_messages_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateForumMessagesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('forum_messages', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('forum_id');
+            $table->unsignedBigInteger('user_id');
+            $table->longText('body');
+            $table->timestamps();
+
+            $table->foreign('forum_id')->references('id')->on('forums')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->index(['forum_id', 'created_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('forum_messages');
+    }
+}

--- a/database/migrations/2026_02_27_000003_create_forum_message_attachments_table.php
+++ b/database/migrations/2026_02_27_000003_create_forum_message_attachments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateForumMessageAttachmentsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('forum_message_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('forum_message_id');
+            $table->string('file_path');
+            $table->string('file_name');
+            $table->string('mime_type', 120)->nullable();
+            $table->unsignedBigInteger('file_size')->default(0);
+            $table->timestamps();
+
+            $table->foreign('forum_message_id')->references('id')->on('forum_messages')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('forum_message_attachments');
+    }
+}

--- a/database/migrations/2026_02_27_000004_create_forum_comments_table.php
+++ b/database/migrations/2026_02_27_000004_create_forum_comments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateForumCommentsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('forum_comments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('forum_message_id');
+            $table->unsignedBigInteger('user_id');
+            $table->text('body');
+            $table->timestamps();
+
+            $table->foreign('forum_message_id')->references('id')->on('forum_messages')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('forum_comments');
+    }
+}

--- a/resources/views/forums/form.blade.php
+++ b/resources/views/forums/form.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app_system')
+
+@section('content')
+    <div class="content">
+        <div class="page-inner">
+            <h4 class="page-title">{{ $isEdit ? 'Editar foro' : 'Nuevo foro' }}</h4>
+
+            <div class="card">
+                <div class="card-body">
+                    <form method="POST" action="{{ $isEdit ? route('forums.update', $forum->id) : route('forums.store') }}">
+                        @csrf
+                        @if ($isEdit)
+                            @method('PUT')
+                        @endif
+
+                        <div class="form-group">
+                            <label>Materia</label>
+                            <select name="materia_id" class="form-control" required>
+                                <option value="">Seleccionar</option>
+                                @foreach ($materias as $materia)
+                                    <option value="{{ $materia->id }}"
+                                        {{ old('materia_id', $forum->materia_id) == $materia->id ? 'selected' : '' }}>
+                                        {{ $materia->nombre }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Título</label>
+                            <input type="text" name="title" class="form-control" maxlength="150"
+                                value="{{ old('title', $forum->title) }}" required>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Descripción</label>
+                            <textarea name="description" rows="4" class="form-control">{{ old('description', $forum->description) }}</textarea>
+                        </div>
+
+                        <button type="submit" class="btn btn-success">{{ $isEdit ? 'Guardar cambios' : 'Crear foro' }}</button>
+                        <a href="{{ route('forums.index') }}" class="btn btn-light">Cancelar</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/forums/index.blade.php
+++ b/resources/views/forums/index.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.app_system')
+
+@section('content')
+    <div class="content">
+        <div class="page-inner">
+            <div class="d-flex align-items-center justify-content-between mb-4">
+                <div>
+                    <h4 class="page-title">Foros por materia</h4>
+                    <p class="mb-0 text-muted">Ingresá a cada foro para ver mensajes y comentarios activos.</p>
+                </div>
+                @if (Auth::user()->hasAnyRole(['Colegio', 'Docente']))
+                    <a href="{{ route('forums.create') }}" class="btn btn-primary">Crear foro</a>
+                @endif
+            </div>
+
+            @if (session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+
+            @if (session('error'))
+                <div class="alert alert-danger">{{ session('error') }}</div>
+            @endif
+
+            @forelse ($materias as $materia)
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <strong>{{ $materia->nombre }}</strong>
+                        <small class="text-muted">{{ optional($materia->cursos)->name }}</small>
+                    </div>
+                    <div class="card-body">
+                        @if ($materia->forums->isEmpty())
+                            <p class="text-muted mb-0">No hay foros creados para esta materia.</p>
+                        @else
+                            <div class="list-group">
+                                @foreach ($materia->forums as $forum)
+                                    <a href="{{ route('forums.show', $forum->id) }}"
+                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <h5 class="mb-1">{{ $forum->title }}</h5>
+                                            <small>{{ $forum->description }}</small>
+                                        </div>
+                                        <span>
+                                            <span class="badge badge-{{ $forum->is_active ? 'success' : 'secondary' }} mr-2">
+                                                {{ $forum->is_active ? 'Activo' : 'Inactivo' }}
+                                            </span>
+                                            <span class="badge badge-info">{{ $forum->messages_count }} mensajes</span>
+                                        </span>
+                                    </a>
+                                @endforeach
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            @empty
+                <div class="alert alert-info">No tenés materias asociadas para visualizar foros.</div>
+            @endforelse
+        </div>
+    </div>
+@endsection

--- a/resources/views/forums/show.blade.php
+++ b/resources/views/forums/show.blade.php
@@ -1,0 +1,109 @@
+@extends('layouts.app_system')
+
+@section('content')
+    <div class="content">
+        <div class="page-inner">
+            <div class="d-flex justify-content-between align-items-start">
+                <div>
+                    <h4 class="page-title">{{ $forum->title }}</h4>
+                    <p class="text-muted mb-1">Materia: {{ $forum->materia->nombre }}</p>
+                    <p>{{ $forum->description }}</p>
+                </div>
+                <div>
+                    <a href="{{ route('forums.index') }}" class="btn btn-light">Volver</a>
+                    @if (Auth::user()->hasAnyRole(['Colegio', 'Docente']))
+                        <a href="{{ route('forums.edit', $forum->id) }}" class="btn btn-warning">Editar</a>
+                        <form method="POST" action="{{ route('forums.toggle_status', $forum->id) }}" class="d-inline">
+                            @csrf
+                            @method('PATCH')
+                            <button class="btn btn-{{ $forum->is_active ? 'secondary' : 'success' }}">
+                                {{ $forum->is_active ? 'Inhabilitar' : 'Habilitar' }}
+                            </button>
+                        </form>
+                    @endif
+                </div>
+            </div>
+
+            @if (session('success'))
+                <div class="alert alert-success">{{ session('success') }}</div>
+            @endif
+            @if (session('error'))
+                <div class="alert alert-danger">{{ session('error') }}</div>
+            @endif
+
+            <div class="card mt-3">
+                <div class="card-header">Publicar mensaje</div>
+                <div class="card-body">
+                    @if (!$forum->is_active)
+                        <div class="alert alert-warning mb-0">Este foro está inactivo y no admite nuevas publicaciones.</div>
+                    @else
+                        <form action="{{ route('forums.messages.store', $forum->id) }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="form-group">
+                                <textarea name="body" class="form-control" rows="3" placeholder="Escribí tu mensaje..." required></textarea>
+                            </div>
+                            <div class="form-group">
+                                <label>Adjuntos (hasta 5 MB por archivo)</label>
+                                <input type="file" name="attachments[]" class="form-control" multiple>
+                            </div>
+                            <button class="btn btn-primary">Publicar</button>
+                        </form>
+                    @endif
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @forelse ($forum->messages->sortByDesc('created_at') as $message)
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between">
+                                <strong>{{ $message->user->last_name }} {{ $message->user->name }}</strong>
+                                <small>{{ $message->created_at->diffForHumans() }}</small>
+                            </div>
+                            <p class="mt-2">{{ $message->body }}</p>
+
+                            @if ($message->attachments->isNotEmpty())
+                                <div class="mb-2">
+                                    @foreach ($message->attachments as $attachment)
+                                        <a class="badge badge-info mr-1" target="_blank"
+                                            href="{{ asset('storage/' . $attachment->file_path) }}">{{ $attachment->file_name }}</a>
+                                    @endforeach
+                                </div>
+                            @endif
+
+                            <hr>
+                            <h6>Comentarios</h6>
+                            @forelse ($message->comments as $comment)
+                                <div class="mb-2 pl-2 border-left">
+                                    <small>
+                                        <strong>{{ $comment->user->last_name }} {{ $comment->user->name }}</strong>
+                                        · {{ $comment->created_at->diffForHumans() }}
+                                    </small>
+                                    <div>{{ $comment->body }}</div>
+                                </div>
+                            @empty
+                                <small class="text-muted">Sin comentarios.</small>
+                            @endforelse
+
+                            @if ($forum->is_active)
+                                <form action="{{ route('forums.comments.store', [$forum->id, $message->id]) }}" method="POST"
+                                    class="mt-2">
+                                    @csrf
+                                    <div class="input-group">
+                                        <input type="text" name="body" class="form-control" maxlength="1500"
+                                            placeholder="Escribí un comentario" required>
+                                        <div class="input-group-append">
+                                            <button class="btn btn-outline-primary">Comentar</button>
+                                        </div>
+                                    </div>
+                                </form>
+                            @endif
+                        </div>
+                    </div>
+                @empty
+                    <div class="alert alert-info">Todavía no hay mensajes en este foro.</div>
+                @endforelse
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/acciones_rapidas.blade.php
+++ b/resources/views/layouts/acciones_rapidas.blade.php
@@ -26,10 +26,10 @@
                              <span class="text">Nueva entrega</span>
                          </div>
                      </a>
-                     <a class="col-6 col-md-4 p-0" href="entregas.php">
+                     <a class="col-6 col-md-4 p-0" href="{{ route('forums.index') }}">
                          <div class="quick-actions-item">
-                             <i class="flaticon-message"></i>
-                             <span class="text">Ver entregas</span>
+                             <i class="flaticon-chat-1"></i>
+                             <span class="text">Foros</span>
                          </div>
                      </a>
                      <a class="col-6 col-md-4 p-0" href="misnotas.php">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -29,11 +29,18 @@
                          <div class="notif-scroll scrollbar-outer">
                              <div class="notif-center">
                                  @forelse ($notifications as $notification)
-                                     <a href="{{ url('/mensajes/' . $notification->data['announcement_id']) }}">
-                                         <div class="notif-icon notif-primary"> <i class="fa fa-envelope"></i> </div>
+                                     @php
+                                         $url = $notification->data['url'] ??
+                                             (isset($notification->data['announcement_id'])
+                                                 ? url('/mensajes/' . $notification->data['announcement_id'])
+                                                 : '#');
+                                         $icon = $notification->data['icon'] ?? 'fa-envelope';
+                                     @endphp
+                                     <a href="{{ $url }}">
+                                         <div class="notif-icon notif-primary"> <i class="fa {{ $icon }}"></i> </div>
                                          <div class="notif-content">
                                              <span class="block">
-                                                 {{ $notification->data['subject'] }}
+                                                 {{ $notification->data['subject'] ?? ($notification->data['title'] ?? 'Nueva notificación') }}
                                              </span>
                                              <span class="time">
                                                  {{ $notification->created_at->diffForHumans() }}

--- a/resources/views/layouts/sidebar/sidebar_school.blade.php
+++ b/resources/views/layouts/sidebar/sidebar_school.blade.php
@@ -93,6 +93,29 @@
     </div>
 </li>
 
+
+<li class="nav-item">
+    <a data-toggle="collapse" href="#foros" class="collapsed" aria-expanded="false">
+        <i class="fas fa-comments"></i>
+        <p>Foros</p>
+        <span class="caret"></span>
+    </a>
+    <div class="collapse" id="foros">
+        <ul class="nav nav-collapse">
+            <li>
+                <a href="{{ route('forums.index') }}">
+                    <span class="sub-item">Ver foros</span>
+                </a>
+            </li>
+            <li>
+                <a href="{{ route('forums.create') }}">
+                    <span class="sub-item">Crear foro</span>
+                </a>
+            </li>
+        </ul>
+    </div>
+</li>
+
 <li class="nav-item">
     <a data-toggle="collapse" href="#alumnos" class="collapsed" aria-expanded="false">
         <i class="fas fa-user-graduate"></i>

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -1,8 +1,6 @@
 @extends('layouts.app_system')
 
 @section('content')
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
-
     <div class="content">
         <div class="page-inner">
             <div class="page-header">
@@ -15,19 +13,24 @@
                         <div class="card-body">
                             <div class="list-group">
                                 @forelse ($notifications as $notification)
-                                    <a href="{{ url('/mensajes/' . $notification->data['announcement_id']) }}"
-                                        class="list-group-item list-group-item-action">
+                                    @php
+                                        $url = $notification->data['url'] ??
+                                            (isset($notification->data['announcement_id'])
+                                                ? url('/mensajes/' . $notification->data['announcement_id'])
+                                                : '#');
+                                    @endphp
+                                    <a href="{{ $url }}" class="list-group-item list-group-item-action">
                                         <div class="d-flex w-100 justify-content-between">
-                                            <h5 class="mb-1">{{ $notification->data['subject'] }}</h5>
+                                            <h5 class="mb-1">{{ $notification->data['subject'] ?? ($notification->data['title'] ?? 'Notificación') }}</h5>
                                             <small>{{ $notification->created_at->diffForHumans() }}</small>
                                         </div>
-                                        <p class="mb-1">
-                                            {{ $notification->data['message'] ?? 'Tienes una nueva notificación.' }}</p>
+                                        <p class="mb-1">{{ $notification->data['message'] ?? ($notification->data['content'] ?? 'Tienes una nueva notificación.') }}</p>
                                     </a>
                                 @empty
                                     <p class="text-muted">No tienes notificaciones.</p>
                                 @endforelse
                             </div>
+                            <div class="mt-3">{{ $notifications->links() }}</div>
                         </div>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\HomeController as Home;
 use App\Http\Controllers\MessageController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\ForumController;
 use App\Http\Controllers\School\OrientacionCursosController;
 use App\Http\Controllers\Schools\AcademicPeriodsController;
 use App\Http\Controllers\Schools\AlumnosController as SchoolsAlumnosController;
@@ -32,6 +33,22 @@ Auth::routes();
 Route::middleware(['auth'])->group(function () {
 
     Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');
+
+    Route::prefix('foros')->as('forums.')->group(function () {
+        Route::get('', [ForumController::class, 'index'])->name('index');
+        Route::get('{forum}', [ForumController::class, 'show'])->name('show');
+        Route::post('{forum}/mensajes', [ForumController::class, 'storeMessage'])->name('messages.store');
+        Route::post('{forum}/mensajes/{message}/comentarios', [ForumController::class, 'storeComment'])->name('comments.store');
+
+        Route::middleware('role:Colegio|Docente')->group(function () {
+            Route::get('crear/nuevo', [ForumController::class, 'create'])->name('create');
+            Route::post('', [ForumController::class, 'store'])->name('store');
+            Route::get('{forum}/editar', [ForumController::class, 'edit'])->name('edit');
+            Route::put('{forum}', [ForumController::class, 'update'])->name('update');
+            Route::patch('{forum}/estado', [ForumController::class, 'toggleStatus'])->name('toggle_status');
+        });
+    });
+
     Route::group(['prefix' => 'mensajes', 'as' => 'mensajes.'], function () {
         Route::get('', [EmailController::class, 'index'])->name('index'); // Lista de mensajes
         Route::get('crear', [EmailController::class, 'create'])->name('create'); // Crear mensaje


### PR DESCRIPTION
### Motivation
- Permitir que docentes y alumnos participen en foros organizados por materia y que los usuarios vean únicamente los foros de las materias que les corresponden.
- Garantizar que solo los roles `Colegio` y `Docente` puedan crear/editar/inhabilitar foros y que los foros no se eliminen físicamente.
- Notificar a los usuarios involucrados cuando se publica un nuevo mensaje en un foro y ofrecer adjuntos en las publicaciones.

### Description
- Se agregaron migraciones para `forums`, `forum_messages`, `forum_message_attachments` y `forum_comments` que crean las tablas y relaciones necesarias.
- Se añadieron modelos `Forum`, `ForumMessage`, `ForumMessageAttachment` y `ForumComment` y se vinculó `Materias::forums()` para listar foros por materia.
- Se implementó `ForumController` con acciones para listado por materia, creación/edición/inhabilitación (sin borrado), publicación de mensajes con adjuntos, y comentarios, incluyendo validaciones y control de acceso por rol y materia.
- Se añadieron rutas bajo el prefijo `/foros` para participación y administración, la notificación `ForumMessageNotification` (base de datos) y vistas: `forums.index`, `forums.form` y `forums.show`, además de ajustes en navbar/sidebar y la vista de notificaciones para soportar payloads genéricos con URL e icono.

### Testing
- Se ejecutaron comprobaciones de sintaxis PHP (`php -l`) sobre los nuevos controladores y modelos y resultaron sin errores. (éxito)
- Se verificó sintaxis de `app/Models/Materias.php`, `routes/web.php` y `app/Http/Controllers/NotificationController.php` con `php -l` y no se detectaron errores. (éxito)
- Se intentó ejecutar la suite con `php artisan test` pero falló debido a dependencias de Composer ausentes (`vendor/autoload.php`), por lo que la batería de tests automatizados completa no pudo correrse en este entorno. (fallido)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a182e77b3c832aa54564493e1c3969)