### PR TITLE
Mostrar cursos inscriptos y materias asignadas en perfil de docente

### DIFF
--- a/app/Http/Controllers/Schools/ProfesoresController.php
+++ b/app/Http/Controllers/Schools/ProfesoresController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Schools;
 use App\Http\Controllers\Controller;
 use App\Models\Profesors;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
@@ -225,10 +226,43 @@ class ProfesoresController extends Controller
 
     public function showProfile(int $user_prof_id)
     {
-        // Buscar el  por ID
-        $prof = Profesors::with('user')->findOrFail($user_prof_id);
+        // Buscar el docente por ID
+        $prof = Profesors::with(['user', 'subjects.cursos'])->findOrFail($user_prof_id);
+
+        $assignedSubjects = collect();
+        $assignedCourses = collect();
+
+        if (Auth::user()->hasRole('Docente') || Auth::user()->hasRole('Colegio')) {
+            $assignedSubjects = DB::table('subject_teacher as st')
+                ->join('materias as m', 'm.id', '=', 'st.subject_courses_id')
+                ->join('cursos as c', 'c.id', '=', 'm.curso_id')
+                ->leftJoin('subject_academic_courses as sac', 'sac.materia_id', '=', 'm.id')
+                ->leftJoin('academic_year_courses as ayc', 'ayc.id', '=', 'sac.academic_year_course_id')
+                ->leftJoin('academic_years as ay', 'ay.id', '=', 'ayc.academic_year_id')
+                ->where('st.teacher_id', $prof->id)
+                ->select(
+                    'm.id as materia_id',
+                    'm.nombre as materia_nombre',
+                    'c.id as curso_id',
+                    'c.name as curso_nombre',
+                    'ay.name as ciclo_lectivo',
+                    'ay.status as ciclo_status',
+                    'st.created_at as asignado_en'
+                )
+                ->orderByDesc('st.created_at')
+                ->get()
+                ->map(function ($item) {
+                    $item->estado_asignacion = ((int) $item->ciclo_status === 1) ? 'Actual' : 'Histórico';
+                    return $item;
+                });
+
+            $assignedCourses = $assignedSubjects
+                ->unique('curso_id')
+                ->values();
+        }
+
         Log::debug($prof);
-        // Devolver la vista con los datos del pro$prof
-        return view('school.profesors.profile.index', compact('prof'));
+        // Devolver la vista con los datos del docente
+        return view('school.profesors.profile.index', compact('prof', 'assignedSubjects', 'assignedCourses'));
     }
 }

--- a/resources/views/school/profesors/profile/index.blade.php
+++ b/resources/views/school/profesors/profile/index.blade.php
@@ -47,6 +47,16 @@
                                     <a class="nav-link active" id="datos-tab" data-bs-toggle="tab" href="#datos"
                                         role="tab" aria-controls="datos" aria-selected="true">Datos personales</a>
                                 </li>
+                                @if (Auth::user()->hasRole('Docente') || Auth::user()->hasRole('Colegio'))
+                                    <li class="nav-item" role="presentation">
+                                        <a class="nav-link" id="cursos-tab" data-bs-toggle="tab" href="#cursos"
+                                            role="tab" aria-controls="cursos" aria-selected="false">Cursos inscriptos</a>
+                                    </li>
+                                    <li class="nav-item" role="presentation">
+                                        <a class="nav-link" id="materias-tab" data-bs-toggle="tab" href="#materias"
+                                            role="tab" aria-controls="materias" aria-selected="false">Materias asignadas</a>
+                                    </li>
+                                @endif
                             </ul>
                             @include('school.profesors.profile.personal_data')
                         </div>

--- a/resources/views/school/profesors/profile/personal_data.blade.php
+++ b/resources/views/school/profesors/profile/personal_data.blade.php
@@ -18,5 +18,66 @@
            </div>
        </div>
 
+       @if (Auth::user()->hasRole('Docente') || Auth::user()->hasRole('Colegio'))
+           <div class="tab-pane fade" id="cursos" role="tabpanel" aria-labelledby="cursos-tab">
+               <div class="row mt-3">
+                   <div class="col-12">
+                       @if (isset($assignedCourses) && $assignedCourses->count())
+                           <ul class="list-group">
+                               @foreach ($assignedCourses as $course)
+                                   <li class="list-group-item d-flex justify-content-between align-items-center">
+                                       <span>{{ $course->curso_nombre }}</span>
+                                       @if (!empty($course->ciclo_lectivo))
+                                           <span class="badge bg-primary">{{ $course->ciclo_lectivo }}</span>
+                                       @endif
+                                   </li>
+                               @endforeach
+                           </ul>
+                       @else
+                           <p class="text-muted mb-0">No tiene cursos inscriptos.</p>
+                       @endif
+                   </div>
+               </div>
+           </div>
+
+           <div class="tab-pane fade" id="materias" role="tabpanel" aria-labelledby="materias-tab">
+               <div class="row mt-3">
+                   <div class="col-12">
+                       @if (isset($assignedSubjects) && $assignedSubjects->count())
+                           <div class="table-responsive">
+                               <table class="table table-striped mb-0">
+                                   <thead>
+                                       <tr>
+                                           <th>Materia</th>
+                                           <th>Curso</th>
+                                           <th>Ciclo lectivo</th>
+                                           <th>Estado</th>
+                                       </tr>
+                                   </thead>
+                                   <tbody>
+                                       @foreach ($assignedSubjects as $subject)
+                                           <tr>
+                                               <td>{{ $subject->materia_nombre }}</td>
+                                               <td>{{ $subject->curso_nombre }}</td>
+                                               <td>{{ $subject->ciclo_lectivo ?? 'Sin ciclo' }}</td>
+                                               <td>
+                                                   <span
+                                                       class="badge {{ $subject->estado_asignacion === 'Actual' ? 'bg-success' : 'bg-secondary' }}">
+                                                       {{ $subject->estado_asignacion }}
+                                                   </span>
+                                               </td>
+                                           </tr>
+                                       @endforeach
+                                   </tbody>
+                               </table>
+                           </div>
+                       @else
+                           <p class="text-muted mb-0">No tiene materias asignadas.</p>
+                       @endif
+                   </div>
+               </div>
+           </div>
+       @endif
+
 
    </div>


### PR DESCRIPTION
### Motivation
- Agregar al perfil del módulo de docentes la información de `Cursos inscripto` y el `Listado de materias` (actual/histórico) para usuarios con rol `Docente` o `Colegio`.

### Description
- En `ProfesoresController::showProfile` se cargan relaciones y se añadió una consulta con `DB` que une `subject_teacher`, `materias`, `cursos` y los ciclos lectivos para construir `assignedSubjects` y `assignedCourses` con estado (`Actual`/`Histórico`).
- Se añadió `use Illuminate\Support\Facades\DB;` y se mapeó el resultado para incluir `materia_nombre`, `curso_nombre`, `ciclo_lectivo` y `estado_asignacion`.
- Se actualizaron las vistas `resources/views/school/profesors/profile/index.blade.php` y `resources/views/school/profesors/profile/personal_data.blade.php` para incluir dos pestañas nuevas (`Cursos inscriptos` y `Materias asignadas`) y render condicional según el rol (`Docente` o `Colegio`).
- La vista muestra lista de cursos (únicos) y una tabla de materias con curso, ciclo lectivo y un `badge` indicando si la asignación es `Actual` o `Histórico`.

### Testing
- Se ejecutó la verificación de sintaxis PHP con `php -l` sobre `app/Http/Controllers/Schools/ProfesoresController.php` y las vistas modificadas, y no se detectaron errores de sintaxis. (éxito)
- Se intentó levantar la app con `php artisan serve` pero falló por dependencias faltantes (`vendor/autoload.php`), por lo que no se realizó una prueba funcional en servidor local (falló por entorno).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1adb1a9bc832a89cb492467adfd1f)