### PR TITLE
Add grade history, report card and KPIs to student profile with charts

### DIFF
--- a/app/Http/Controllers/Schools/AlumnosController.php
+++ b/app/Http/Controllers/Schools/AlumnosController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Client\Request as ClientRequest;
 use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request;
 use Yajra\DataTables\Facades\DataTables;
@@ -241,7 +242,80 @@ class AlumnosController extends Controller
         // Buscar el alumno por ID
         $alumno = Students::findOrFail($user_student_id);
 
+        $gradesQuery = DB::table('grades as g')
+            ->leftJoin('academic_periods as ap', 'ap.id', '=', 'g.academic_period_id')
+            ->leftJoin('subject_academic_courses as sac', 'sac.id', '=', 'g.academic_year_course_materia_id')
+            ->leftJoin('materias as m', 'm.id', '=', 'sac.materia_id')
+            ->where('g.student_id', $alumno->id);
+
+        $gradeMovements = (clone $gradesQuery)
+            ->select(
+                'g.grade_value',
+                'g.observations',
+                'g.created_at',
+                'm.nombre as materia',
+                'ap.name as periodo'
+            )
+            ->orderByDesc('g.created_at')
+            ->get();
+
+        $latestMovements = $gradeMovements->take(8);
+
+        $reportCard = (clone $gradesQuery)
+            ->select(
+                'm.nombre as materia',
+                'ap.name as periodo',
+                DB::raw('ROUND(AVG(g.grade_value), 2) as promedio'),
+                DB::raw('MIN(g.grade_value) as nota_minima'),
+                DB::raw('MAX(g.grade_value) as nota_maxima'),
+                DB::raw('COUNT(g.id) as evaluaciones')
+            )
+            ->groupBy('m.nombre', 'ap.name')
+            ->orderBy('m.nombre')
+            ->orderBy('ap.name')
+            ->get();
+
+        $averageGrade = (float) $gradeMovements->avg('grade_value');
+        $lastGrade = optional($gradeMovements->first())->grade_value;
+        $riskSubjects = $reportCard->where('promedio', '<', 6)->count();
+        $approvalRate = $gradeMovements->count() > 0
+            ? round(($gradeMovements->where('grade_value', '>=', 6)->count() / $gradeMovements->count()) * 100, 2)
+            : 0;
+
+        $performanceKpis = [
+            'promedio_general' => $gradeMovements->count() > 0 ? round($averageGrade, 2) : null,
+            'total_evaluaciones' => $gradeMovements->count(),
+            'ultima_nota' => $lastGrade,
+            'materias_en_riesgo' => $riskSubjects,
+            'porcentaje_aprobacion' => $approvalRate,
+        ];
+
+        $trendData = $gradeMovements
+            ->sortBy('created_at')
+            ->values()
+            ->map(function ($movement) {
+                return [
+                    'label' => Carbon::parse($movement->created_at)->format('d/m'),
+                    'value' => (float) $movement->grade_value,
+                ];
+            });
+
+        $subjectAverages = $reportCard
+            ->groupBy('materia')
+            ->map(function ($items) {
+                return round($items->avg(function ($item) {
+                    return (float) $item->promedio;
+                }), 2);
+            });
+
+        $kpiCharts = [
+            'trend_labels' => $trendData->pluck('label')->values(),
+            'trend_values' => $trendData->pluck('value')->values(),
+            'subject_labels' => $subjectAverages->keys()->values(),
+            'subject_values' => $subjectAverages->values(),
+        ];
+
         // Devolver la vista con los datos del alumno
-        return view('school.alumnos.profile', compact('alumno'));
+        return view('school.alumnos.profile', compact('alumno', 'latestMovements', 'reportCard', 'performanceKpis', 'kpiCharts'));
     }
 }

--- a/resources/views/school/alumnos/profile.blade.php
+++ b/resources/views/school/alumnos/profile.blade.php
@@ -56,6 +56,19 @@
                                     <a class="nav-link" id="medicos-tab" data-bs-toggle="tab" href="#medicos" role="tab"
                                         aria-controls="medicos" aria-selected="false">Información Médica</a>
                                 </li>
+                                <li class="nav-item" role="presentation">
+                                    <a class="nav-link" id="movimientos-tab" data-bs-toggle="tab" href="#movimientos"
+                                        role="tab" aria-controls="movimientos" aria-selected="false">Últimos
+                                        movimientos</a>
+                                </li>
+                                <li class="nav-item" role="presentation">
+                                    <a class="nav-link" id="boletin-tab" data-bs-toggle="tab" href="#boletin" role="tab"
+                                        aria-controls="boletin" aria-selected="false">Desempeño / Boletín</a>
+                                </li>
+                                <li class="nav-item" role="presentation">
+                                    <a class="nav-link" id="kpis-tab" data-bs-toggle="tab" href="#kpis" role="tab"
+                                        aria-controls="kpis" aria-selected="false">KPIs</a>
+                                </li>
                             </ul>
 
                             <!-- Contenido de las pestañas -->
@@ -101,6 +114,142 @@
                                         </div>
                                     </div>
                                 </div>
+
+                                <div class="tab-pane fade" id="movimientos" role="tabpanel"
+                                    aria-labelledby="movimientos-tab">
+                                    <div class="mt-3 table-responsive">
+                                        <table class="table table-striped table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th>Fecha</th>
+                                                    <th>Materia</th>
+                                                    <th>Período</th>
+                                                    <th>Nota</th>
+                                                    <th>Observación</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @forelse ($latestMovements as $movement)
+                                                    <tr>
+                                                        <td>{{ \Illuminate\Support\Carbon::parse($movement->created_at)->format('d/m/Y H:i') }}
+                                                        </td>
+                                                        <td>{{ $movement->materia ?? '-' }}</td>
+                                                        <td>{{ $movement->periodo ?? '-' }}</td>
+                                                        <td>{{ $movement->grade_value }}</td>
+                                                        <td>{{ $movement->observations ?: '-' }}</td>
+                                                    </tr>
+                                                @empty
+                                                    <tr>
+                                                        <td colspan="5" class="text-center text-muted">Sin movimientos
+                                                            registrados.</td>
+                                                    </tr>
+                                                @endforelse
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="tab-pane fade" id="boletin" role="tabpanel" aria-labelledby="boletin-tab">
+                                    <div class="mt-3 table-responsive">
+                                        <table class="table table-bordered table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th>Materia</th>
+                                                    <th>Período</th>
+                                                    <th>Promedio</th>
+                                                    <th>Nota mínima</th>
+                                                    <th>Nota máxima</th>
+                                                    <th>Evaluaciones</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @forelse ($reportCard as $item)
+                                                    <tr>
+                                                        <td>{{ $item->materia ?? '-' }}</td>
+                                                        <td>{{ $item->periodo ?? '-' }}</td>
+                                                        <td>{{ $item->promedio }}</td>
+                                                        <td>{{ $item->nota_minima }}</td>
+                                                        <td>{{ $item->nota_maxima }}</td>
+                                                        <td>{{ $item->evaluaciones }}</td>
+                                                    </tr>
+                                                @empty
+                                                    <tr>
+                                                        <td colspan="6" class="text-center text-muted">No hay notas para
+                                                            generar el boletín.</td>
+                                                    </tr>
+                                                @endforelse
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="tab-pane fade" id="kpis" role="tabpanel" aria-labelledby="kpis-tab">
+                                    <div class="row mt-3">
+                                        <div class="col-md-4 mb-3">
+                                            <div class="card bg-light">
+                                                <div class="card-body">
+                                                    <h6 class="text-muted">Promedio general</h6>
+                                                    <h4>{{ $performanceKpis['promedio_general'] ?? 'N/A' }}</h4>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <div class="card bg-light">
+                                                <div class="card-body">
+                                                    <h6 class="text-muted">Total evaluaciones</h6>
+                                                    <h4>{{ $performanceKpis['total_evaluaciones'] }}</h4>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-4 mb-3">
+                                            <div class="card bg-light">
+                                                <div class="card-body">
+                                                    <h6 class="text-muted">Última nota</h6>
+                                                    <h4>{{ $performanceKpis['ultima_nota'] ?? 'N/A' }}</h4>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <div class="card bg-light">
+                                                <div class="card-body">
+                                                    <h6 class="text-muted">Materias en riesgo (&lt; 6)</h6>
+                                                    <h4>{{ $performanceKpis['materias_en_riesgo'] }}</h4>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <div class="card bg-light">
+                                                <div class="card-body">
+                                                    <h6 class="text-muted">% aprobación</h6>
+                                                    <h4>{{ $performanceKpis['porcentaje_aprobacion'] }}%</h4>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="row mt-2">
+                                        <div class="col-md-6 mb-4">
+                                            <div class="card">
+                                                <div class="card-header">
+                                                    <h5 class="mb-0">Evolución de notas</h5>
+                                                </div>
+                                                <div class="card-body">
+                                                    <canvas id="kpiTrendChart" height="140"></canvas>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6 mb-4">
+                                            <div class="card">
+                                                <div class="card-header">
+                                                    <h5 class="mb-0">Promedio por materia</h5>
+                                                </div>
+                                                <div class="card-body">
+                                                    <canvas id="kpiSubjectChart" height="140"></canvas>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
 
@@ -111,4 +260,71 @@
             </div>
         </div>
     </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const trendLabels = @json($kpiCharts['trend_labels']);
+            const trendValues = @json($kpiCharts['trend_values']);
+            const subjectLabels = @json($kpiCharts['subject_labels']);
+            const subjectValues = @json($kpiCharts['subject_values']);
+
+            if (document.getElementById('kpiTrendChart') && trendValues.length > 0) {
+                new Chart(document.getElementById('kpiTrendChart'), {
+                    type: 'line',
+                    data: {
+                        labels: trendLabels,
+                        datasets: [{
+                            label: 'Nota',
+                            data: trendValues,
+                            borderColor: '#1572E8',
+                            backgroundColor: 'rgba(21, 114, 232, 0.15)',
+                            fill: true,
+                            tension: 0.25
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            yAxes: [{
+                                ticks: {
+                                    beginAtZero: true,
+                                    suggestedMax: 10
+                                }
+                            }]
+                        }
+                    }
+                });
+            }
+
+            if (document.getElementById('kpiSubjectChart') && subjectValues.length > 0) {
+                new Chart(document.getElementById('kpiSubjectChart'), {
+                    type: 'bar',
+                    data: {
+                        labels: subjectLabels,
+                        datasets: [{
+                            label: 'Promedio',
+                            data: subjectValues,
+                            backgroundColor: 'rgba(255, 159, 64, 0.7)',
+                            borderColor: '#ff9f40',
+                            borderWidth: 1
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            yAxes: [{
+                                ticks: {
+                                    beginAtZero: true,
+                                    suggestedMax: 10
+                                }
+                            }]
+                        }
+                    }
+                });
+            }
+        });
+    </script>
 @endsection
+


### PR DESCRIPTION
### Motivation
- Provide richer student profile details by exposing grade movements, a per-subject report card and performance KPIs to help teachers and staff monitor student progress.
- Surface trend and subject-average visualizations so users can quickly assess performance over time.

### Description
- Updated `AlumnosController::showProfile` to query the `grades` table (joined with `academic_periods`, `subject_academic_courses` and `materias`) and compute `latestMovements`, `reportCard`, `performanceKpis` and `kpiCharts`, and passed them to the view. 
- Added `DB` import and built aggregated queries for averages, minima/maxima, counts and approval rates, plus trend and subject-average datasets. 
- Extended `resources/views/school/alumnos/profile.blade.php` to add new tabs for "Últimos movimientos", "Desempeño / Boletín" and "KPIs", tables for movements and report card, KPI cards, and two Chart.js canvases. 
- Injected inline JavaScript that renders a line chart for grade evolution and a bar chart for average by subject using `@json(...)` data prepared by the controller.

### Testing
- Ran the Laravel test suite via `phpunit` and `php artisan test`, and all existing automated tests passed. 
- No new automated tests were added for the report queries or chart rendering in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ad7c3aac832ab6bba0b1e9bcd772)